### PR TITLE
Rename bit_num to hash_num

### DIFF
--- a/movielens/config.json
+++ b/movielens/config.json
@@ -14,7 +14,7 @@
     ]
   },
   "parameter" : {
-    "bit_num" : 128
+    "hash_num" : 128
     },
   "method": "lsh"
 }


### PR DESCRIPTION
This change is driven by https://github.com/jubatus/jubatus/pull/454. Only `movielens` is modified. I checked that it runs correctly.
